### PR TITLE
Force arena saving after load

### DIFF
--- a/src/main/java/net/caseif/flint/common/minigame/CommonMinigame.java
+++ b/src/main/java/net/caseif/flint/common/minigame/CommonMinigame.java
@@ -200,6 +200,8 @@ public abstract class CommonMinigame implements Minigame {
                         );
                         arena.getSpawnPointMap().remove(0); // remove initial placeholder spawn
                         arena.configure(arenaJson);
+                        // force save
+                        arena.store();
                         getArenaMap().put(arena.getId(), arena);
                     } else {
                         CommonCore.logWarning("Invalid object \"" + entry.getKey() + "\"in arena store");


### PR DESCRIPTION
Fix critical bug which caused spawns to be wiped on reboot. This happens because the arena is saved on initialisation and this simply writes over that save.